### PR TITLE
Refactor Dockerfile to be more efficient/useful

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
-FROM fedora
+FROM fedora:25
 
-RUN dnf -y install go
-RUN dnf -y install git
-RUN dnf -y install make
+RUN dnf -y install \
+  git \
+  go \
+  make \
+&& dnf clean all
 
 ENV GOPATH /root/gopath
 ENV PATH=$PATH:$GOPATH/bin
 
-RUN mkdir -p /root/gopath/src/github.com/twtiger/gosecco
+COPY . "$GOPATH/src/github.com/twtiger/gosecco"
+WORKDIR "$GOPATH/src/github.com/twtiger/gosecco"
+
+RUN make deps-dev
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
* reduces size from 973MB to 706MB
* reduces build time
* adds code to GOPATH rather than just creating the empty directory
* adds default CMD and builds development dependencies into image
  so it's ready to work with
* specifies a specific Fedora version to use